### PR TITLE
Add resource for managing user assigned identities

### DIFF
--- a/examples/apply_main.tf
+++ b/examples/apply_main.tf
@@ -1,0 +1,9 @@
+module "authorization" {
+  source = "registry.terraform.io/telekom-mms/authorization/azurerm"
+  user_assigned_identity = {
+    uai-mms = {
+      location            = "westeurope"
+      resource_group_name = "rg-mms-github"
+    }
+  }
+}

--- a/examples/full_main.tf
+++ b/examples/full_main.tf
@@ -1,0 +1,14 @@
+module "authorization" {
+  source = "registry.terraform.io/telekom-mms/authorization/azurerm"
+  user_assigned_identity = {
+    uai-mms = {
+      location            = "westeurope"
+      resource_group_name = "rg-mms-github"
+      tags = {
+        project     = "mms-github"
+        environment = terraform.workspace
+        managed-by  = "terraform"
+      }
+    }
+  }
+}

--- a/examples/min_main.tf
+++ b/examples/min_main.tf
@@ -1,0 +1,9 @@
+module "authorization" {
+  source = "registry.terraform.io/telekom-mms/authorization/azurerm"
+  user_assigned_identity = {
+    uai-mms = {
+      location            = "westeurope"
+      resource_group_name = "rg-mms-github"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -20,3 +20,12 @@ resource "azurerm_role_assignment" "role_assignment" {
   description                            = local.role_assignment[each.key].description
   skip_service_principal_aad_check       = local.role_assignment[each.key].skip_service_principal_aad_check
 }
+
+resource "azurerm_user_assigned_identity" "user_assigned_identity" {
+  for_each = var.user_assigned_identity
+
+  name                = local.user_assigned_identity[each.key].name == "" ? each.key : local.user_assigned_identity[each.key].name
+  location            = local.user_assigned_identity[each.key].location
+  resource_group_name = local.user_assigned_identity[each.key].resource_group_name
+  tags                = local.user_assigned_identity[each.key].tags
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,17 @@ output "role_assignments" {
   }
 }
 
+output "user_assigned_identity" {
+  description = "Outputs all attributes of resource_type."
+  value = {
+    for user_assigned_identity in keys(azurerm_user_assigned_identity.user_assigned_identity) :
+    user_assigned_identity => {
+      for key, value in azurerm_user_assigned_identity.user_assigned_identity[user_assigned_identity] :
+      key => value
+    }
+  }
+}
+
 output "variables" {
   description = "Displays all configurable variables passed by the module. __default__ = predefined values per module. __merged__ = result of merging the default values and custom values passed to the module"
   value = {
@@ -20,6 +31,10 @@ output "variables" {
       role_assignment = {
         for key in keys(var.role_assignment) :
         key => local.role_assignment[key]
+      }
+      user_assigned_identity = {
+        for key in keys(var.user_assigned_identity) :
+        key => local.user_assigned_identity[key]
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@ variable "role_assignment" {
   default     = {}
   description = "Resource definition, default settings are defined within locals and merged with var settings. For more information look at [Outputs](#Outputs)."
 }
+variable "user_assigned_identity" {
+  type        = any
+  default     = {}
+  description = "Resource definition, default settings are defined within locals and merged with var settings. For more information look at [Outputs](#Outputs)."
+}
 
 locals {
   default = {
@@ -17,6 +22,11 @@ locals {
       description                            = null
       skip_service_principal_aad_check       = null
     }
+
+    user_assigned_identity = {
+      name = ""
+      tags = {}
+    }
   }
 
   // compare and merge custom and default values
@@ -24,12 +34,23 @@ locals {
     for role_assignment in keys(var.role_assignment) :
     role_assignment => merge(local.default.role_assignment, var.role_assignment[role_assignment])
   }
+  user_assigned_identity_values = {
+    for user_assigned_identity in keys(var.user_assigned_identity) :
+    user_assigned_identity => merge(local.default.user_assigned_identity, var.user_assigned_identity[user_assigned_identity])
+  }
 
   // deep merge of all custom and default values
   role_assignment = {
     for role_assignment in keys(var.role_assignment) :
     role_assignment => merge(
       local.role_assignment_values[role_assignment],
+      {}
+    )
+  }
+  user_assigned_identity = {
+    for user_assigned_identity in keys(var.user_assigned_identity) :
+    user_assigned_identity => merge(
+      local.user_assigned_identity_values[user_assigned_identity],
       {}
     )
   }


### PR DESCRIPTION
Added the possibility to manage user assigned identity with this module (see https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity).